### PR TITLE
feat: add customizable tray menu with template-based display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@electron-toolkit/preload": "^3.0.2",
                 "@electron-toolkit/utils": "^4.0.0",
                 "@miniben90/x-win": "^3.4.0",
+                "@napi-rs/canvas": "^0.1.97",
                 "@sentry/electron": "^5.7.0",
                 "@sentry/vite-plugin": "^2.22.8",
                 "@solidtime/api": "^0.0.6",
@@ -2635,6 +2636,255 @@
             ],
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/@napi-rs/canvas": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+            "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+            "license": "MIT",
+            "workspaces": [
+                "e2e/*"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "optionalDependencies": {
+                "@napi-rs/canvas-android-arm64": "0.1.97",
+                "@napi-rs/canvas-darwin-arm64": "0.1.97",
+                "@napi-rs/canvas-darwin-x64": "0.1.97",
+                "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+                "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+                "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+                "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+                "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+                "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+                "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+                "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+            }
+        },
+        "node_modules/@napi-rs/canvas-android-arm64": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+            "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-darwin-arm64": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+            "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-darwin-x64": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+            "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+            "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+            "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+            "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+            "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+            "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-linux-x64-musl": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+            "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+            "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+            "version": "0.1.97",
+            "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+            "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
             }
         },
         "node_modules/@neon-rs/load": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@electron-toolkit/preload": "^3.0.2",
         "@electron-toolkit/utils": "^4.0.0",
         "@miniben90/x-win": "^3.4.0",
+        "@napi-rs/canvas": "^0.1.97",
         "@sentry/electron": "^5.7.0",
         "@sentry/vite-plugin": "^2.22.8",
         "@solidtime/api": "^0.0.6",

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/electron/main'
 export interface AppSettings {
     widgetActivated: boolean
     trayTimerActivated: boolean
+    trayTemplate: string
     idleDetectionEnabled: boolean
     idleThresholdMinutes: number
     activityTrackingEnabled: boolean
@@ -17,6 +18,7 @@ export interface AppSettings {
 export const DEFAULT_SETTINGS: AppSettings = {
     widgetActivated: true,
     trayTimerActivated: true,
+    trayTemplate: '{hours}:{minutes}:{seconds} – {project_colored}',
     idleDetectionEnabled: true,
     idleThresholdMinutes: 5,
     activityTrackingEnabled: false, // Off by default for privacy
@@ -26,6 +28,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 const SETTING_KEYS = {
     WIDGET_ACTIVATED: 'widget_activated',
     TRAY_TIMER_ACTIVATED: 'tray_timer_activated',
+    TRAY_TEMPLATE: 'tray_template',
     IDLE_DETECTION_ENABLED: 'idle_detection_enabled',
     IDLE_THRESHOLD_MINUTES: 'idle_threshold_minutes',
     ACTIVITY_TRACKING_ENABLED: 'activity_tracking_enabled',
@@ -91,12 +94,14 @@ export async function getAppSettings(): Promise<AppSettings> {
         const [
             widgetActivated,
             trayTimerActivated,
+            trayTemplate,
             idleDetectionEnabled,
             idleThresholdMinutes,
             activityTrackingEnabled,
         ] = await Promise.all([
             getSetting(SETTING_KEYS.WIDGET_ACTIVATED),
             getSetting(SETTING_KEYS.TRAY_TIMER_ACTIVATED),
+            getSetting(SETTING_KEYS.TRAY_TEMPLATE),
             getSetting(SETTING_KEYS.IDLE_DETECTION_ENABLED),
             getSetting(SETTING_KEYS.IDLE_THRESHOLD_MINUTES),
             getSetting(SETTING_KEYS.ACTIVITY_TRACKING_ENABLED),
@@ -111,6 +116,7 @@ export async function getAppSettings(): Promise<AppSettings> {
                 trayTimerActivated !== null
                     ? trayTimerActivated === 'true'
                     : DEFAULT_SETTINGS.trayTimerActivated,
+            trayTemplate: trayTemplate ?? DEFAULT_SETTINGS.trayTemplate,
             idleDetectionEnabled:
                 idleDetectionEnabled !== null
                     ? idleDetectionEnabled === 'true'
@@ -154,6 +160,12 @@ export async function updateAppSettings(
                     SETTING_KEYS.TRAY_TIMER_ACTIVATED,
                     String(partialSettings.trayTimerActivated)
                 )
+            )
+        }
+
+        if (partialSettings.trayTemplate !== undefined) {
+            promises.push(
+                setSetting(SETTING_KEYS.TRAY_TEMPLATE, partialSettings.trayTemplate)
             )
         }
 

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -1,35 +1,123 @@
-import { app, BrowserWindow, ipcMain, Menu, nativeImage, Tray, nativeTheme } from 'electron'
+import {
+    app,
+    BrowserWindow,
+    ipcMain,
+    Menu,
+    nativeImage,
+    Tray,
+    nativeTheme,
+    screen,
+} from 'electron'
+import { createCanvas, loadImage, type Image as CanvasImage } from '@napi-rs/canvas'
 import activeTrayIcon from '../../resources/solidtime_trayTemplate@4x.png?asset'
 import inactiveTrayIcon from '../../resources/solidtime_emptyTemplate@4x.png?asset'
 import activeTrayIconInverted from '../../resources/solidtime_trayTemplate_inverted@4x.png?asset'
 import inactiveTrayIconInverted from '../../resources/solidtime_emptyTemplate_inverted@4x.png?asset'
-import { TimeEntry } from '@solidtime/api'
+import { type TimeEntry } from '@solidtime/api'
+import { getAppSettings } from './settings'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 dayjs.extend(duration)
 
-let timerInterval: NodeJS.Timeout | undefined = undefined
+interface TraySegment {
+    text: string
+    color?: string
+}
 
-let currentTrayTimeEntry: TimeEntry | null = null
+type TrayTimeEntry = TimeEntry & { project: string; projectColor: string; task: string }
+
+let timerInterval: NodeJS.Timeout | undefined = undefined
+let currentTrayTimeEntry: TrayTimeEntry | null = null
+let currentTrayTemplate = '{hours}:{minutes}:{seconds} – {project_colored}'
+
+// Cached canvas images of tray icons for compositing
+let canvasIconActive: CanvasImage | null = null
+let canvasIconActiveInverted: CanvasImage | null = null
+
+async function preloadCanvasIcons() {
+    try {
+        ;[canvasIconActive, canvasIconActiveInverted] = await Promise.all([
+            loadImage(activeTrayIcon),
+            loadImage(activeTrayIconInverted),
+        ])
+    } catch (e) {
+        console.error('Failed to preload tray icons for canvas:', e)
+    }
+}
+
+async function loadTrayTemplate() {
+    try {
+        const settings = await getAppSettings()
+        currentTrayTemplate = settings.trayTemplate
+    } catch (e) {
+        console.error('Failed to load tray template:', e)
+    }
+}
 
 function isTimerRunning(timeEntry: TimeEntry | null): boolean {
-    // empty timers have a empty string as start time because of the init state in timeEntries.ts
     return !!(timeEntry && timeEntry.start && timeEntry.start !== '')
 }
 
 function getIconPath(active: boolean) {
-    // On macOS, template images (with 'Template' in filename) are automatically inverted by the OS
-    // So we should always use the non-inverted version on macOS
     if (process.platform === 'darwin') {
         return active ? activeTrayIcon : inactiveTrayIcon
     }
-
-    // On other platforms, manually handle dark mode
     const isDarkMode = nativeTheme.shouldUseDarkColors
     if (active) {
         return isDarkMode ? activeTrayIconInverted : activeTrayIcon
     }
     return isDarkMode ? inactiveTrayIconInverted : inactiveTrayIcon
+}
+
+function parseTemplate(
+    template: string,
+    data: Record<string, { value: string; color?: string }>
+): TraySegment[] {
+    const segments: TraySegment[] = []
+    const regex = /\{(\w+)\}/g
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+
+    while ((match = regex.exec(template)) !== null) {
+        // Add literal text before this placeholder
+        if (match.index > lastIndex) {
+            segments.push({ text: template.slice(lastIndex, match.index) })
+        }
+        // Resolve the placeholder
+        const key = match[1]
+        const entry = data[key]
+        if (entry && entry.value) {
+            segments.push({ text: entry.value, color: entry.color })
+        }
+        lastIndex = match.index + match[0].length
+    }
+    // Add trailing literal text
+    if (lastIndex < template.length) {
+        segments.push({ text: template.slice(lastIndex) })
+    }
+    return segments
+}
+
+function cleanSegments(segments: TraySegment[]): TraySegment[] {
+    // Remove trailing literal-only segments that are purely separators/whitespace
+    while (segments.length > 0) {
+        const last = segments[segments.length - 1]
+        if (!last.color && last.text.trim().replace(/[–\-|:]/g, '').trim() === '') {
+            segments.pop()
+        } else {
+            break
+        }
+    }
+    // Remove leading separator-like segments
+    while (segments.length > 0) {
+        const first = segments[0]
+        if (!first.color && first.text.trim().replace(/[–\-|:]/g, '').trim() === '') {
+            segments.shift()
+        } else {
+            break
+        }
+    }
+    return segments
 }
 
 function buildMenu(mainWindow: BrowserWindow, timeEntry: TimeEntry | null) {
@@ -74,37 +162,109 @@ function buildMenu(mainWindow: BrowserWindow, timeEntry: TimeEntry | null) {
 }
 
 export function initializeTray(mainWindow: Electron.BrowserWindow) {
+    preloadCanvasIcons()
+    loadTrayTemplate()
+
     const tray = new Tray(nativeImage.createFromPath(getIconPath(false)))
     tray.setToolTip('solidtime')
     tray.setTitle('')
     tray.setContextMenu(buildMenu(mainWindow, null))
 
     nativeTheme.on('updated', () => {
-        const isRunning = isTimerRunning(currentTrayTimeEntry)
-        tray.setImage(nativeImage.createFromPath(getIconPath(isRunning)))
+        if (isTimerRunning(currentTrayTimeEntry) && currentTrayTimeEntry) {
+            updateTimerInterval(currentTrayTimeEntry, tray)
+        } else {
+            tray.setImage(nativeImage.createFromPath(getIconPath(false)))
+        }
     })
 
     return tray
 }
 
-function updateTimerInterval(timeEntry: TimeEntry, tray: Tray) {
+function buildTrayTitleImage(segments: TraySegment[]): Electron.NativeImage {
+    const scaleFactor = screen.getPrimaryDisplay().scaleFactor || 2
+    const isDark = nativeTheme.shouldUseDarkColors
+    const icon = isDark ? canvasIconActiveInverted : canvasIconActive
+    const height = 22
+    const iconSize = 16
+    const gap = 4
+    const font = `${13 * scaleFactor}px -apple-system, "SF Pro Text", "Helvetica Neue", sans-serif`
+    const textColor = isDark ? 'rgba(255, 255, 255, 0.85)' : 'rgba(0, 0, 0, 0.85)'
+
+    // Measure total text width
+    const measureCtx = createCanvas(1, 1).getContext('2d')
+    measureCtx.font = font
+    let totalTextWidth = 0
+    for (const seg of segments) {
+        totalTextWidth += measureCtx.measureText(seg.text).width
+    }
+
+    const iconPx = iconSize * scaleFactor
+    const gapPx = gap * scaleFactor
+    const textStart = icon ? iconPx + gapPx : 0
+    const totalWidth = Math.ceil(textStart + totalTextWidth + gapPx)
+
+    const canvas = createCanvas(totalWidth, height * scaleFactor)
+    const ctx = canvas.getContext('2d')
+
+    // Draw icon centered vertically
+    if (icon) {
+        const iconY = (height * scaleFactor - iconPx) / 2
+        ctx.drawImage(icon, 0, iconY, iconPx, iconPx)
+    }
+
+    // Draw each segment sequentially
+    ctx.font = font
+    const baselineY = 16 * scaleFactor
+    let x = textStart
+    for (const seg of segments) {
+        ctx.fillStyle = seg.color ?? textColor
+        ctx.fillText(seg.text, x, baselineY)
+        x += measureCtx.measureText(seg.text).width
+    }
+
+    return nativeImage.createFromBuffer(canvas.toBuffer('image/png'), { scaleFactor })
+}
+
+function updateTimerInterval(timeEntry: TrayTimeEntry, tray: Tray) {
     if (isTimerRunning(timeEntry)) {
-        const duration = dayjs.duration(dayjs().diff(dayjs(timeEntry.start), 'second'), 's')
-        // duration formatted to HH:MM
-        const hours = Math.floor(duration.asHours()).toString().padStart(2, '0')
-        const minutes = duration.minutes().toString().padStart(2, '0')
-        const formattedDuration = ` ${hours}:${minutes}`
-        tray.setTitle(formattedDuration, { fontType: 'monospacedDigit' })
+        const dur = dayjs.duration(dayjs().diff(dayjs(timeEntry.start), 'second'), 's')
+        const hours = Math.floor(dur.asHours()).toString().padStart(2, '0')
+        const minutes = dur.minutes().toString().padStart(2, '0')
+        const seconds = dur.seconds().toString().padStart(2, '0')
+
+        const data: Record<string, { value: string; color?: string }> = {
+            hours: { value: hours },
+            minutes: { value: minutes },
+            seconds: { value: seconds },
+            project: { value: timeEntry.project },
+            project_colored: {
+                value: timeEntry.project || 'No project',
+                color: timeEntry.projectColor || undefined,
+            },
+            description: { value: timeEntry.description || '' },
+            task: { value: timeEntry.task || '' },
+        }
+
+        const segments = cleanSegments(parseTemplate(currentTrayTemplate, data))
+
+        if (segments.length === 0) {
+            // Fallback: always show at least the time
+            segments.push({ text: `${hours}:${minutes}:${seconds}` })
+        }
+
+        const titleImage = buildTrayTitleImage(segments)
+        tray.setTitle('')
+        tray.setImage(titleImage)
     }
 }
 
 export function registerTrayListeners(tray: Tray, mainWindow: BrowserWindow) {
     ipcMain.on('updateTrayState', (_, serializedTimeEntry: string, showTimer: boolean = true) => {
         if (serializedTimeEntry) {
-            const timeEntry = JSON.parse(serializedTimeEntry) as TimeEntry
+            const timeEntry = JSON.parse(serializedTimeEntry) as TrayTimeEntry
             currentTrayTimeEntry = timeEntry
             const isRunning = isTimerRunning(timeEntry)
-            tray.setImage(nativeImage.createFromPath(getIconPath(isRunning)))
             tray.setToolTip(
                 isRunning ? 'solidtime - Timer is running' : 'solidtime - Timer is stopped'
             )
@@ -116,9 +276,18 @@ export function registerTrayListeners(tray: Tray, mainWindow: BrowserWindow) {
                 updateTimerInterval(timeEntry, tray)
                 timerInterval = setInterval(() => updateTimerInterval(timeEntry, tray), 1000)
             } else {
+                tray.setImage(nativeImage.createFromPath(getIconPath(false)))
                 tray.setTitle('')
             }
             tray.setContextMenu(buildMenu(mainWindow, timeEntry))
+        }
+    })
+
+    ipcMain.on('updateTrayTemplate', (_, template: string) => {
+        currentTrayTemplate = template
+        // Re-render immediately if timer is running
+        if (isTimerRunning(currentTrayTimeEntry) && currentTrayTimeEntry) {
+            updateTimerInterval(currentTrayTimeEntry, tray)
         }
     })
 }

--- a/src/preload/interface.d.ts
+++ b/src/preload/interface.d.ts
@@ -1,6 +1,7 @@
 export interface AppSettings {
     widgetActivated: boolean
     trayTimerActivated: boolean
+    trayTemplate: string
     idleDetectionEnabled: boolean
     idleThresholdMinutes: number
     activityTrackingEnabled: boolean
@@ -40,6 +41,7 @@ export interface IElectronAPI {
     onStartTimer: (callback: () => void) => void
     onStopTimer: (callback: () => void) => void
     updateTrayState: (timeEntry: string, showTimer: boolean) => void
+    updateTrayTemplate: (template: string) => void
     updateAutoUpdater: () => void
     updateIdleThreshold: (thresholdMinutes: number) => void
     updateIdleDetectionEnabled: (enabled: boolean) => void

--- a/src/preload/main.ts
+++ b/src/preload/main.ts
@@ -31,6 +31,8 @@ if (process.contextIsolated || true) {
                 ipcRenderer.on('updateError', (_event, value) => callback(value)),
             updateTrayState: (timeEntry: string, showTimer: boolean) =>
                 ipcRenderer.send('updateTrayState', timeEntry, showTimer),
+            updateTrayTemplate: (template: string) =>
+                ipcRenderer.send('updateTrayTemplate', template),
             updateAutoUpdater: () => ipcRenderer.send('updateAutoUpdater'),
             updateIdleThreshold: (thresholdMinutes: number) =>
                 ipcRenderer.send('updateIdleThreshold', thresholdMinutes),

--- a/src/renderer/src/components/MainTimeEntryTable.vue
+++ b/src/renderer/src/components/MainTimeEntryTable.vue
@@ -184,14 +184,27 @@ async function createTag(newTagName: string): Promise<Tag | undefined> {
     return undefined
 }
 
-// Watch for current time entry changes and update tray state
-watch(currentTimeEntry, () => {
-    updateTrayState({ ...currentTimeEntry.value })
-})
+// Send current time entry + project + task info to the tray
+function sendTrayUpdate() {
+    const project = projects.value?.find(
+        (p) => p.id === currentTimeEntry.value.project_id
+    )
+    const task = tasks.value?.find(
+        (t) => t.id === currentTimeEntry.value.task_id
+    )
+    updateTrayState({
+        ...currentTimeEntry.value,
+        project: project?.name ?? '',
+        projectColor: project?.color ?? '',
+        task: task?.name ?? '',
+    })
+}
 
-watch(isTrayTimerActivated, () => {
-    updateTrayState({ ...currentTimeEntry.value })
-})
+// Watch for current time entry, projects, tasks, and tray setting changes
+watch(currentTimeEntry, sendTrayUpdate)
+watch(isTrayTimerActivated, sendTrayUpdate)
+watch(projects, sendTrayUpdate)
+watch(tasks, sendTrayUpdate)
 
 // Watch for active state changes and manage live timer
 watchEffect(() => {

--- a/src/renderer/src/pages/SettingsPage.vue
+++ b/src/renderer/src/pages/SettingsPage.vue
@@ -15,6 +15,7 @@ import { logout } from '../utils/oauth.ts'
 import {
     isWidgetActivated,
     isTrayTimerActivated,
+    trayTemplate,
     idleDetectionEnabled,
     idleThresholdMinutes,
     activityTrackingEnabled,
@@ -28,7 +29,7 @@ import {
     useDeleteActivityPeriodsInRangeMutation,
     useClearIconCacheMutation,
 } from '../utils/windowActivities.ts'
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { dayjs } from '../utils/dayjs.ts'
 import { EllipsisVerticalIcon } from '@heroicons/vue/24/outline'
@@ -75,6 +76,88 @@ const showDeleteActivityPeriodsRangeModal = ref(false)
 const selectedRangeLabel = ref('')
 const selectedRangeStart = ref('')
 const selectedRangeEnd = ref('')
+
+// Tray template live preview
+const previewSeconds = ref(5025) // starts at 01:23:45
+let previewInterval: ReturnType<typeof setInterval> | null = null
+
+interface PreviewSegment {
+    text: string
+    color?: string
+}
+
+function resolvePreviewTemplate(template: string, totalSeconds: number): PreviewSegment[] {
+    const h = Math.floor(totalSeconds / 3600).toString().padStart(2, '0')
+    const m = Math.floor((totalSeconds % 3600) / 60).toString().padStart(2, '0')
+    const s = (totalSeconds % 60).toString().padStart(2, '0')
+
+    const data: Record<string, { value: string; color?: string }> = {
+        hours: { value: h },
+        minutes: { value: m },
+        seconds: { value: s },
+        project: { value: 'Project Name' },
+        project_colored: { value: 'Project Name', color: '#ef5350' },
+        description: { value: 'Task description' },
+        task: { value: 'Task name' },
+    }
+
+    const segments: PreviewSegment[] = []
+    const regex = /\{(\w+)\}/g
+    let lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = regex.exec(template)) !== null) {
+        if (match.index > lastIndex) {
+            segments.push({ text: template.slice(lastIndex, match.index) })
+        }
+        const key = match[1]
+        const entry = data[key]
+        if (entry && entry.value) {
+            segments.push({ text: entry.value, color: entry.color })
+        }
+        lastIndex = match.index + match[0].length
+    }
+    if (lastIndex < template.length) {
+        segments.push({ text: template.slice(lastIndex) })
+    }
+    return segments
+}
+
+const previewSegments = computed(() =>
+    resolvePreviewTemplate(trayTemplate.value, previewSeconds.value)
+)
+
+function startPreviewTimer() {
+    if (previewInterval) return
+    previewInterval = setInterval(() => {
+        previewSeconds.value++
+    }, 1000)
+}
+
+function stopPreviewTimer() {
+    if (previewInterval) {
+        clearInterval(previewInterval)
+        previewInterval = null
+    }
+    previewSeconds.value = 5025
+}
+
+watch(isTrayTimerActivated, (enabled) => {
+    if (enabled) {
+        startPreviewTimer()
+    } else {
+        stopPreviewTimer()
+    }
+})
+
+onMounted(() => {
+    if (isTrayTimerActivated.value) {
+        startPreviewTimer()
+    }
+})
+
+onUnmounted(() => {
+    stopPreviewTimer()
+})
 
 type TimeRangeOption = { label: string; minutes: number }
 
@@ -293,6 +376,39 @@ watch(activityTrackingEnabled, (enabled) => {
                         <Checkbox v-model:checked="isTrayTimerActivated" name="tray_timer" />
                         <span class="ms-2 text-sm">Show Tray / Menu Bar Timer</span>
                     </label>
+                    <div v-if="isTrayTimerActivated" class="ml-6 space-y-3">
+                        <div>
+                            <label for="trayTemplate" class="text-sm">Display Template</label>
+                            <input
+                                id="trayTemplate"
+                                v-model="trayTemplate"
+                                type="text"
+                                class="mt-1 block w-full px-2 py-1 text-sm bg-card-background border border-card-background-separator rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                :placeholder="'{hours}:{minutes}:{seconds} – {project_colored}'" />
+                        </div>
+                        <div class="text-xs text-muted-foreground space-y-1">
+                            <div>Available placeholders:</div>
+                            <div class="flex flex-wrap gap-x-3 gap-y-1">
+                                <span><code>{hours}</code> — hours</span>
+                                <span><code>{minutes}</code> — minutes</span>
+                                <span><code>{seconds}</code> — seconds</span>
+                                <span><code>{project_colored}</code> — project (colored)</span>
+                                <span><code>{project}</code> — project (plain)</span>
+                                <span><code>{description}</code> — description</span>
+                                <span><code>{task}</code> — task name</span>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <span class="text-xs text-muted-foreground">Preview:</span>
+                            <span class="text-sm font-mono">
+                                <span
+                                    v-for="seg in previewSegments"
+                                    :key="seg.text"
+                                    :style="seg.color ? { color: seg.color } : {}"
+                                    >{{ seg.text }}</span>
+                            </span>
+                        </div>
+                    </div>
                     <label class="flex items-center">
                         <Checkbox v-model:checked="idleDetectionEnabled" name="idleDetection" />
                         <span class="ms-2 text-sm">Enable Idle Detection</span>

--- a/src/renderer/src/utils/settings.ts
+++ b/src/renderer/src/utils/settings.ts
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 export interface AppSettings {
     widgetActivated: boolean
     trayTimerActivated: boolean
+    trayTemplate: string
     idleDetectionEnabled: boolean
     idleThresholdMinutes: number
     activityTrackingEnabled: boolean
@@ -11,6 +12,7 @@ export interface AppSettings {
 // Reactive settings that sync with the database
 export const isWidgetActivated = ref(true)
 export const isTrayTimerActivated = ref(true)
+export const trayTemplate = ref('{hours}:{minutes}:{seconds} – {project_colored}')
 export const idleDetectionEnabled = ref(true)
 export const idleThresholdMinutes = ref(5)
 export const activityTrackingEnabled = ref(false) // Off by default
@@ -28,6 +30,7 @@ export async function initializeSettings() {
         if (result.success && result.data) {
             isWidgetActivated.value = result.data.widgetActivated
             isTrayTimerActivated.value = result.data.trayTimerActivated
+            trayTemplate.value = result.data.trayTemplate
             idleDetectionEnabled.value = result.data.idleDetectionEnabled
             idleThresholdMinutes.value = result.data.idleThresholdMinutes
             activityTrackingEnabled.value = result.data.activityTrackingEnabled
@@ -42,6 +45,11 @@ export async function initializeSettings() {
 
         watch(isTrayTimerActivated, (value) => {
             updateSetting({ trayTimerActivated: value })
+        })
+
+        watch(trayTemplate, (value) => {
+            updateSetting({ trayTemplate: value })
+            window.electronAPI.updateTrayTemplate(value)
         })
 
         watch(idleDetectionEnabled, (value) => {

--- a/src/renderer/src/utils/tray.ts
+++ b/src/renderer/src/utils/tray.ts
@@ -1,6 +1,8 @@
 import { type TimeEntry } from '@solidtime/api'
 import { isTrayTimerActivated } from './settings'
 
-export async function updateTrayState(timeEntry: TimeEntry) {
+export async function updateTrayState(
+    timeEntry: TimeEntry & { project: string; projectColor: string; task: string }
+) {
     window.electronAPI.updateTrayState(JSON.stringify(timeEntry), isTrayTimerActivated.value)
 }


### PR DESCRIPTION
## Summary
Adds a colored project and template of the tray menu in settings. Still not validated on all platforms and a bit risky to merge it yet I guess, but may be someone can help me checking it on other OS and leave some feedback so I can adjust it for the main version.

![telegram-cloud-photo-size-2-5364015812127167276-y](https://github.com/user-attachments/assets/dcbf6ced-f091-41fa-b153-43d27477cd8d)
![telegram-cloud-photo-size-2-5364015812127167275-y](https://github.com/user-attachments/assets/d32143a5-9a60-430d-be98-c1c60c574074)

- Replaces the simple timer-only tray title with a canvas-rendered display that supports configurable templates
- Adds `@napi-rs/canvas` for native tray icon + text compositing, enabling colored project names directly in the menu bar / system tray
- Introduces a `trayTemplate` setting with placeholders: `{hours}`, `{minutes}`, `{seconds}`, `{project}`, `{project_colored}`, `{description}`, `{task}`
- Adds a live preview and template editor in the Settings page
- Supports dark/light mode with proper text colors

## Changes

| File | Description |
|------|-------------|
| `src/main/tray.ts` | Canvas-based tray rendering with template parsing, segment coloring, and icon compositing |
| `src/main/settings.ts` | New `trayTemplate` setting with persistence |
| `src/renderer/src/pages/SettingsPage.vue` | Template editor with live preview |
| `src/renderer/src/components/MainTimeEntryTable.vue` | Pass project/task info to tray via IPC |
| `src/renderer/src/utils/settings.ts` | Reactive `trayTemplate` binding |
| `src/preload/main.ts`, `src/preload/interface.d.ts` | New `updateTrayTemplate` IPC channel |
| `src/renderer/src/utils/tray.ts` | Extended type to include project/task data |
| `package.json` | Added `@napi-rs/canvas` dependency |

## Screenshots

The tray now renders like: `🕐 01:23:45 – Project Name` with the project name in its assigned color.

_(Will add actual screenshots if requested)_

## Test plan

- [x] Verify tray displays timer with default template on macOS
- [ ] Verify tray displays timer on Windows/Linux with dark and light themes
- [x] Change template in Settings and confirm tray updates live
- [ ] Remove project placeholder from template and confirm timer-only display works
- [ ] Stop timer and confirm tray returns to inactive icon
- [ ] Restart app and confirm template persists from settings